### PR TITLE
Fix compatibility with ESP8266WebServer

### DIFF
--- a/MPU6050BasicExample.ino
+++ b/MPU6050BasicExample.ino
@@ -192,7 +192,7 @@ int intPin = 12;  // This can be changed, 2 and 3 are the Arduinos ext int pins
 int16_t accelCount[3];           // Stores the 16-bit signed accelerometer sensor output
 float ax, ay, az;                // Stores the real accel value in g's
 int16_t gyroCount[3];            // Stores the 16-bit signed gyro sensor output
-float gx, gy, gz;                // Stores the real gyro value in degrees per seconds
+float gyrox, gyroy, gyroz;                // Stores the real gyro value in degrees per seconds
 float gyroBias[3], accelBias[3]; // Bias corrections for gyro and accelerometer
 int16_t tempCount;               // Stores the internal chip temperature sensor output 
 float temperature;               // Scaled temperature in degrees Celsius
@@ -288,9 +288,9 @@ void loop()
     getGres();
  
     // Calculate the gyro value into actual degrees per second
-    gx = (float)gyroCount[0]*gRes - gyroBias[0];  // get actual gyro value, this depends on scale being set
-    gy = (float)gyroCount[1]*gRes - gyroBias[1];  
-    gz = (float)gyroCount[2]*gRes - gyroBias[2];   
+    gyrox = (float)gyroCount[0]*gRes - gyroBias[0];  // get actual gyro value, this depends on scale being set
+    gyroy = (float)gyroCount[1]*gRes - gyroBias[1];  
+    gyroz = (float)gyroCount[2]*gRes - gyroBias[2];   
 
     tempCount = readTempData();  // Read the x/y/z adc values
     temperature = ((float) tempCount) / 340. + 36.53; // Temperature in degrees Centigrade
@@ -305,9 +305,9 @@ void loop()
     Serial.print("Z-acceleration: "); Serial.print(1000*az); Serial.println(" mg"); 
  
     // Print gyro values in degree/sec
-    Serial.print("X-gyro rate: "); Serial.print(gx, 1); Serial.print(" degrees/sec "); 
-    Serial.print("Y-gyro rate: "); Serial.print(gy, 1); Serial.print(" degrees/sec "); 
-    Serial.print("Z-gyro rate: "); Serial.print(gz, 1); Serial.println(" degrees/sec"); 
+    Serial.print("X-gyro rate: "); Serial.print(gyrox, 1); Serial.print(" degrees/sec "); 
+    Serial.print("Y-gyro rate: "); Serial.print(gyroy, 1); Serial.print(" degrees/sec "); 
+    Serial.print("Z-gyro rate: "); Serial.print(gyroz, 1); Serial.println(" degrees/sec"); 
     
    // Print temperature in degrees Centigrade      
     Serial.print("Temperature is ");  Serial.print(temperature, 2);  Serial.println(" degrees C"); // Print T values to tenths of s degree C
@@ -323,9 +323,9 @@ void loop()
     display.setCursor(48, 16); display.print((int16_t)(1000*az)); 
     display.setCursor(72, 16); display.print("mg");
     
-    display.setCursor(0,  24); display.print((int16_t)(gx)); 
-    display.setCursor(24, 24); display.print((int16_t)(gy)); 
-    display.setCursor(48, 24); display.print((int16_t)(gz)); 
+    display.setCursor(0,  24); display.print((int16_t)(gyrox)); 
+    display.setCursor(24, 24); display.print((int16_t)(gyroy)); 
+    display.setCursor(48, 24); display.print((int16_t)(gyroz)); 
     display.setCursor(66, 24); display.print("o/s");     
    
     display.setCursor(0,  40); display.print("Gyro T  "); 

--- a/MPU6050IMU.ino
+++ b/MPU6050IMU.ino
@@ -194,7 +194,7 @@ boolean blinkOn = false;
 int16_t accelCount[3];  // Stores the 16-bit signed accelerometer sensor output
 float ax, ay, az;       // Stores the real accel value in g's
 int16_t gyroCount[3];   // Stores the 16-bit signed gyro sensor output
-float gx, gy, gz;       // Stores the real gyro value in degrees per seconds
+float gyrox, gyroy, gyroz;       // Stores the real gyro value in degrees per seconds
 float gyroBias[3] = {0, 0, 0}, accelBias[3] = {0, 0, 0}; // Bias corrections for gyro and accelerometer
 int16_t tempCount;   // Stores the real internal chip temperature in degrees Celsius
 float temperature;
@@ -320,9 +320,9 @@ void loop()
     getGres();
  
     // Calculate the gyro value into actual degrees per second
-    gx = (float)gyroCount[0]*gRes;  // get actual gyro value, this depends on scale being set
-    gy = (float)gyroCount[1]*gRes;  
-    gz = (float)gyroCount[2]*gRes;   
+    gyrox = (float)gyroCount[0]*gRes;  // get actual gyro value, this depends on scale being set
+    gyroy = (float)gyroCount[1]*gRes;  
+    gyroz = (float)gyroCount[2]*gRes;   
 
     tempCount = readTempData();  // Read the x/y/z adc values
     temperature = ((float) tempCount) / 340. + 36.53; // Temperature in degrees Centigrade
@@ -336,7 +336,7 @@ void loop()
 //      zeta = 0.015; // increase gyro bias drift gain after stabilized
 //    }
    // Pass gyro rate as rad/s
-    MadgwickQuaternionUpdate(ax, ay, az, gx*PI/180.0f, gy*PI/180.0f, gz*PI/180.0f);
+    MadgwickQuaternionUpdate(ax, ay, az, gyrox*PI/180.0f, gyroy*PI/180.0f, gyroz*PI/180.0f);
 
     // Serial print and/or display at 0.5 s rate independent of data rates
     delt_t = millis() - count;
@@ -347,9 +347,9 @@ void loop()
     Serial.print(" ay = "); Serial.print((int)1000*ay); 
     Serial.print(" az = "); Serial.print((int)1000*az); Serial.println(" mg");
 
-    Serial.print("gx = "); Serial.print( gx, 1); 
-    Serial.print(" gy = "); Serial.print( gy, 1); 
-    Serial.print(" gz = "); Serial.print( gz, 1); Serial.println(" deg/s");
+    Serial.print("gyrox = "); Serial.print( gyrox, 1); 
+    Serial.print(" gyroy = "); Serial.print( gyroy, 1); 
+    Serial.print(" gyroz = "); Serial.print( gyroz, 1); Serial.println(" deg/s");
     
     Serial.print("q0 = "); Serial.print(q[0]);
     Serial.print(" qx = "); Serial.print(q[1]); 
@@ -390,9 +390,9 @@ void loop()
     display.setCursor(48, 8); display.print((int)(1000*az)); 
     display.setCursor(72, 8); display.print("mg");
     
-    display.setCursor(0,  16); display.print((int)(gx)); 
-    display.setCursor(24, 16); display.print((int)(gy)); 
-    display.setCursor(48, 16); display.print((int)(gz)); 
+    display.setCursor(0,  16); display.print((int)(gyrox)); 
+    display.setCursor(24, 16); display.print((int)(gyroy)); 
+    display.setCursor(48, 16); display.print((int)(gyroz)); 
     display.setCursor(66, 16); display.print("o/s");    
  
     display.setCursor(0,  32); display.print((int)(yaw)); 

--- a/MPU6050Library/MPU6050BasicExample.ino
+++ b/MPU6050Library/MPU6050BasicExample.ino
@@ -35,7 +35,7 @@ int intPin = 12;  // This can be changed, 2 and 3 are the Arduinos ext int pins
 int16_t accelCount[3];           // Stores the 16-bit signed accelerometer sensor output
 float ax, ay, az;                // Stores the real accel value in g's
 int16_t gyroCount[3];            // Stores the 16-bit signed gyro sensor output
-float gx, gy, gz;                // Stores the real gyro value in degrees per seconds
+float gyrox, gyroy, gyroz;                // Stores the real gyro value in degrees per seconds
 float gyroBias[3], accelBias[3]; // Bias corrections for gyro and accelerometer
 int16_t tempCount;               // Stores the internal chip temperature sensor output 
 float temperature;               // Scaled temperature in degrees Celsius
@@ -110,9 +110,9 @@ void loop()
     gRes=mpu.getGres();
  
     // Calculate the gyro value into actual degrees per second
-    gx = (float)gyroCount[0]*gRes - gyroBias[0];  // get actual gyro value, this depends on scale being set
-    gy = (float)gyroCount[1]*gRes - gyroBias[1];  
-    gz = (float)gyroCount[2]*gRes - gyroBias[2];   
+    gyrox = (float)gyroCount[0]*gRes - gyroBias[0];  // get actual gyro value, this depends on scale being set
+    gyroy = (float)gyroCount[1]*gRes - gyroBias[1];  
+    gyroz = (float)gyroCount[2]*gRes - gyroBias[2];   
 
     tempCount = mpu.readTempData();  // Read the x/y/z adc values
     temperature = ((float) tempCount) / 340. + 36.53; // Temperature in degrees Centigrade
@@ -127,9 +127,9 @@ void loop()
     Serial.print("Z-acceleration: "); Serial.print(1000*az); Serial.println(" mg"); 
  
     // Print gyro values in degree/sec
-    Serial.print("X-gyro rate: "); Serial.print(gx, 1); Serial.print(" degrees/sec "); 
-    Serial.print("Y-gyro rate: "); Serial.print(gy, 1); Serial.print(" degrees/sec "); 
-    Serial.print("Z-gyro rate: "); Serial.print(gz, 1); Serial.println(" degrees/sec"); 
+    Serial.print("X-gyro rate: "); Serial.print(gyrox, 1); Serial.print(" degrees/sec "); 
+    Serial.print("Y-gyro rate: "); Serial.print(gyroy, 1); Serial.print(" degrees/sec "); 
+    Serial.print("Z-gyro rate: "); Serial.print(gyroz, 1); Serial.println(" degrees/sec"); 
     
    // Print temperature in degrees Centigrade      
     Serial.print("Temperature is ");  Serial.print(temperature, 2);  Serial.println(" degrees C"); // Print T values to tenths of s degree C

--- a/MPU6050Library/MPU6050IMU.ino
+++ b/MPU6050Library/MPU6050IMU.ino
@@ -37,7 +37,7 @@ boolean blinkOn = false;
 int16_t accelCount[3];  // Stores the 16-bit signed accelerometer sensor output
 float ax, ay, az;       // Stores the real accel value in g's
 int16_t gyroCount[3];   // Stores the 16-bit signed gyro sensor output
-float gx, gy, gz;       // Stores the real gyro value in degrees per seconds
+float gyrox, gyroy, gyroz;       // Stores the real gyro value in degrees per seconds
 float gyroBias[3] = {0, 0, 0}, accelBias[3] = {0, 0, 0}; // Bias corrections for gyro and accelerometer
 int16_t tempCount;   // Stores the real internal chip temperature in degrees Celsius
 float temperature;
@@ -129,9 +129,9 @@ void loop()
     gRes = mpu.getGres();
 
     // Calculate the gyro value into actual degrees per second
-    gx = (float)gyroCount[0] * gRes; // get actual gyro value, this depends on scale being set
-    gy = (float)gyroCount[1] * gRes;
-    gz = (float)gyroCount[2] * gRes;
+    gyrox = (float)gyroCount[0] * gRes; // get actual gyro value, this depends on scale being set
+    gyroy = (float)gyroCount[1] * gRes;
+    gyroz = (float)gyroCount[2] * gRes;
 
     tempCount = mpu.readTempData();  // Read the x/y/z adc values
     temperature = ((float) tempCount) / 340. + 36.53; // Temperature in degrees Centigrade
@@ -145,7 +145,7 @@ void loop()
   //      zeta = 0.015; // increase gyro bias drift gain after stabilized
   //    }
   // Pass gyro rate as rad/s
-  MadgwickQuaternionUpdate(ax, ay, az, gx * PI / 180.0f, gy * PI / 180.0f, gz * PI / 180.0f);
+  MadgwickQuaternionUpdate(ax, ay, az, gyrox * PI / 180.0f, gyroy * PI / 180.0f, gyroz * PI / 180.0f);
 
   // Serial print and/or display at 0.5 s rate independent of data rates
   delt_t = millis() - count;
@@ -156,9 +156,9 @@ void loop()
         Serial.print(" ay = "); Serial.print((int)1000*ay);
         Serial.print(" az = "); Serial.print((int)1000*az); Serial.println(" mg");
 
-        Serial.print("gx = "); Serial.print( gx, 1);
-        Serial.print(" gy = "); Serial.print( gy, 1);
-        Serial.print(" gz = "); Serial.print( gz, 1); Serial.println(" deg/s");
+        Serial.print("gyrox = "); Serial.print( gyrox, 1);
+        Serial.print(" gyroy = "); Serial.print( gyroy, 1);
+        Serial.print(" gyroz = "); Serial.print( gyroz, 1); Serial.println(" deg/s");
 
         Serial.print("q0 = "); Serial.print(q[0]);
         Serial.print(" qx = "); Serial.print(q[1]);
@@ -198,9 +198,9 @@ void loop()
     Serial.print((int)(1000 * az));
     Serial.println(" mg");
 
-    Serial.print((int)(gx)); Serial.print('\t');
-    Serial.print((int)(gy)); Serial.print('\t');
-    Serial.print((int)(gz));
+    Serial.print((int)(gyrox)); Serial.print('\t');
+    Serial.print((int)(gyroy)); Serial.print('\t');
+    Serial.print((int)(gyroz));
     Serial.println(" o/s");
 
     Serial.print((int)(yaw)); Serial.print('\t');
@@ -221,7 +221,7 @@ void loop()
 // device orientation -- which can be converted to yaw, pitch, and roll. Useful for stabilizing quadcopters, etc.
 // The performance of the orientation filter is at least as good as conventional Kalman-based filtering algorithms
 // but is much less computationally intensive---it can be performed on a 3.3 V Pro Mini operating at 8 MHz!
-        void MadgwickQuaternionUpdate(float ax, float ay, float az, float gx, float gy, float gz)
+        void MadgwickQuaternionUpdate(float ax, float ay, float az, float gyrox, float gyroy, float gyroz)
         {
             float q1 = q[0], q2 = q[1], q3 = q[2], q4 = q[3];         // short name local variable for readability
             float norm;                                               // vector norm
@@ -284,15 +284,15 @@ void loop()
             gbiasx += gerrx * deltat * zeta;
             gbiasy += gerry * deltat * zeta;
             gbiasz += gerrz * deltat * zeta;
-            gx -= gbiasx;
-            gy -= gbiasy;
-            gz -= gbiasz;
+            gyrox -= gbiasx;
+            gyroy -= gbiasy;
+            gyroz -= gbiasz;
             
             // Compute the quaternion derivative
-            qDot1 = -_halfq2 * gx - _halfq3 * gy - _halfq4 * gz;
-            qDot2 =  _halfq1 * gx + _halfq3 * gz - _halfq4 * gy;
-            qDot3 =  _halfq1 * gy - _halfq2 * gz + _halfq4 * gx;
-            qDot4 =  _halfq1 * gz + _halfq2 * gy - _halfq3 * gx;
+            qDot1 = -_halfq2 * gyrox - _halfq3 * gyroy - _halfq4 * gyroz;
+            qDot2 =  _halfq1 * gyrox + _halfq3 * gyroz - _halfq4 * gyroy;
+            qDot3 =  _halfq1 * gyroy - _halfq2 * gyroz + _halfq4 * gyrox;
+            qDot4 =  _halfq1 * gyroz + _halfq2 * gyroy - _halfq3 * gyrox;
 
             // Compute then integrate estimated quaternion derivative
             q1 += (qDot1 -(beta * hatDot1)) * deltat;

--- a/STM32F401/main.cpp
+++ b/STM32F401/main.cpp
@@ -137,9 +137,9 @@ int main()
     mpu6050.getGres();
  
     // Calculate the gyro value into actual degrees per second
-    gx = (float)gyroCount[0]*gRes; // - gyroBias[0];  // get actual gyro value, this depends on scale being set
-    gy = (float)gyroCount[1]*gRes; // - gyroBias[1];  
-    gz = (float)gyroCount[2]*gRes; // - gyroBias[2];   
+    gyrox = (float)gyroCount[0]*gRes; // - gyroBias[0];  // get actual gyro value, this depends on scale being set
+    gyroy = (float)gyroCount[1]*gRes; // - gyroBias[1];  
+    gyroz = (float)gyroCount[2]*gRes; // - gyroBias[2];   
 
     tempCount = mpu6050.readTempData();  // Read the x/y/z adc values
     temperature = (tempCount) / 340. + 36.53; // Temperature in degrees Centigrade
@@ -158,7 +158,7 @@ int main()
     }
     
    // Pass gyro rate as rad/s
-    mpu6050.MadgwickQuaternionUpdate(ax, ay, az, gx*PI/180.0f, gy*PI/180.0f, gz*PI/180.0f);
+    mpu6050.MadgwickQuaternionUpdate(ax, ay, az, gyrox*PI/180.0f, gyroy*PI/180.0f, gyroz*PI/180.0f);
 
     // Serial print and/or display at 0.5 s rate independent of data rates
     delt_t = t.read_ms() - count;
@@ -168,9 +168,9 @@ int main()
     pc.printf(" ay = %f", 1000*ay); 
     pc.printf(" az = %f  mg\n\r", 1000*az); 
 
-    pc.printf("gx = %f", gx); 
-    pc.printf(" gy = %f", gy); 
-    pc.printf(" gz = %f  deg/s\n\r", gz); 
+    pc.printf("gyrox = %f", gyrox); 
+    pc.printf(" gyroy = %f", gyroy); 
+    pc.printf(" gyroz = %f  deg/s\n\r", gyroz); 
     
     pc.printf(" temperature = %f  C\n\r", temperature); 
     

--- a/quaternionFilter.ino
+++ b/quaternionFilter.ino
@@ -4,7 +4,7 @@
 // device orientation -- which can be converted to yaw, pitch, and roll. Useful for stabilizing quadcopters, etc.
 // The performance of the orientation filter is at least as good as conventional Kalman-based filtering algorithms
 // but is much less computationally intensive---it can be performed on a 3.3 V Pro Mini operating at 8 MHz!
-        void MadgwickQuaternionUpdate(float ax, float ay, float az, float gx, float gy, float gz)
+        void MadgwickQuaternionUpdate(float ax, float ay, float az, float gyrox, float gyroy, float gyroz)
         {
             float q1 = q[0], q2 = q[1], q3 = q[2], q4 = q[3];         // short name local variable for readability
             float norm;                                               // vector norm
@@ -67,15 +67,15 @@
             gbiasx += gerrx * deltat * zeta;
             gbiasy += gerry * deltat * zeta;
             gbiasz += gerrz * deltat * zeta;
-            gx -= gbiasx;
-            gy -= gbiasy;
-            gz -= gbiasz;
+            gyrox -= gbiasx;
+            gyroy -= gbiasy;
+            gyroz -= gbiasz;
             
             // Compute the quaternion derivative
-            qDot1 = -_halfq2 * gx - _halfq3 * gy - _halfq4 * gz;
-            qDot2 =  _halfq1 * gx + _halfq3 * gz - _halfq4 * gy;
-            qDot3 =  _halfq1 * gy - _halfq2 * gz + _halfq4 * gx;
-            qDot4 =  _halfq1 * gz + _halfq2 * gy - _halfq3 * gx;
+            qDot1 = -_halfq2 * gyrox - _halfq3 * gyroy - _halfq4 * gyroz;
+            qDot2 =  _halfq1 * gyrox + _halfq3 * gyroz - _halfq4 * gyroy;
+            qDot3 =  _halfq1 * gyroy - _halfq2 * gyroz + _halfq4 * gyrox;
+            qDot4 =  _halfq1 * gyroz + _halfq2 * gyroy - _halfq3 * gyrox;
 
             // Compute then integrate estimated quaternion derivative
             q1 += (qDot1 -(beta * hatDot1)) * deltat;


### PR DESCRIPTION
ESP8266WebServer uses 'gz' as a header variable. Renamed 'gx' to 'gyrox', 'gy' to 'gyroy', 'gz' to 'gyroz' in all files for consistency.